### PR TITLE
dot-abi-cli example fix dependencies and update min node to 8.x

### DIFF
--- a/dot-abi-cli/examples/cryptokitties-cli/README.md
+++ b/dot-abi-cli/examples/cryptokitties-cli/README.md
@@ -40,11 +40,11 @@ CONTRACT_ADDRESS=0x06012c8cf97BEaD5deAe237070F9587f8E7A266d
 
 ```bash
 npm install
-./node_modules/.bin/babel-node cryptokitties-cli.js --help
+node cryptokitties-cli.js --help
 
 # ... help results ...
 
-./node_modules/.bin/babel-node cryptokitties-cli.js getKitty 3
+node cryptokitties-cli.js getKitty 3
 
 Result {
   '0': false,

--- a/dot-abi-cli/examples/cryptokitties-cli/cryptokitties-cli.js
+++ b/dot-abi-cli/examples/cryptokitties-cli/cryptokitties-cli.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const yargs = require('yargs');
-const dotAbiCli = require('../../index');
+const dotAbiCli = require('dot-abi-cli');
 const HDWalletProvider = require('truffle-hdwallet-provider');
 const NonceTrackerSubprovider = require('web3-provider-engine/subproviders/nonce-tracker');
 

--- a/dot-abi-cli/examples/cryptokitties-cli/package-lock.json
+++ b/dot-abi-cli/examples/cryptokitties-cli/package-lock.json
@@ -94,16 +94,6 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
-    "anymatch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "optional": true,
-      "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
-      }
-    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -118,31 +108,10 @@
         "readable-stream": "2.3.6"
       }
     },
-    "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "optional": true,
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
-    },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "optional": true
-    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
-    "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "optional": true
     },
     "asn1": {
       "version": "0.2.3",
@@ -172,12 +141,6 @@
         "lodash": "4.17.10"
       }
     },
-    "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "optional": true
-    },
     "async-eventemitter": {
       "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
       "requires": {
@@ -203,35 +166,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
-    },
-    "babel-cli": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
-      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
-      "requires": {
-        "babel-core": "6.26.3",
-        "babel-polyfill": "6.26.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "chokidar": "1.7.0",
-        "commander": "2.15.1",
-        "convert-source-map": "1.5.1",
-        "fs-readdir-recursive": "1.1.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.10",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.7",
-        "v8flags": "2.1.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-        }
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -730,23 +664,6 @@
         "babel-types": "6.26.0"
       }
     },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
-      }
-    },
     "babel-preset-env": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
@@ -897,12 +814,6 @@
     "bignumber.js": {
       "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
     },
-    "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-      "optional": true
-    },
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
@@ -1007,17 +918,6 @@
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "optional": true,
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
       }
     },
     "brorand": {
@@ -1199,23 +1099,6 @@
       "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
       "requires": {
         "functional-red-black-tree": "1.0.1"
-      }
-    },
-    "chokidar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "optional": true,
-      "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.2.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
       }
     },
     "chownr": {
@@ -1645,6 +1528,4615 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
+    "dot-abi-cli": {
+      "version": "file:../..",
+      "requires": {
+        "@ledgerhq/hw-app-eth": "4.7.3",
+        "@ledgerhq/hw-transport-node-hid": "4.7.6",
+        "bluebird": "3.5.1",
+        "chalk": "2.4.1",
+        "debug": "3.1.0",
+        "dotenv": "5.0.1",
+        "fast-safe-stringify": "2.0.4",
+        "ledger-wallet-provider": "2.0.1-beta.2",
+        "lodash": "4.17.10",
+        "truffle-hdwallet-provider": "0.0.3",
+        "web3": "1.0.0-beta.30",
+        "web3-provider-engine": "13.8.0",
+        "yargs": "11.0.0"
+      },
+      "dependencies": {
+        "@ledgerhq/hw-app-eth": {
+          "version": "4.7.3",
+          "bundled": true,
+          "requires": {
+            "@ledgerhq/hw-transport": "4.7.3"
+          }
+        },
+        "@ledgerhq/hw-transport": {
+          "version": "4.7.3",
+          "bundled": true,
+          "requires": {
+            "events": "2.0.0"
+          }
+        },
+        "@ledgerhq/hw-transport-node-hid": {
+          "version": "4.7.6",
+          "bundled": true,
+          "requires": {
+            "@ledgerhq/hw-transport": "4.7.3",
+            "node-hid": "0.7.2"
+          }
+        },
+        "abstract-leveldown": {
+          "version": "2.6.3",
+          "bundled": true,
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        },
+        "accepts": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "mime-types": "2.1.18",
+            "negotiator": "0.6.1"
+          }
+        },
+        "aes-js": {
+          "version": "0.2.4",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "bundled": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "any-promise": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "asn1.js": {
+          "version": "4.10.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.1"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "async": {
+          "version": "2.6.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "4.17.10"
+          }
+        },
+        "async-eventemitter": {
+          "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+          "bundled": true,
+          "requires": {
+            "async": "2.6.0"
+          }
+        },
+        "async-limiter": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "babel-core": {
+          "version": "6.26.3",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.10",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+              "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+            }
+          }
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-assignable-expression": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-define-map": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-get-function-arity": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-helper-remap-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-replace-supers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-optimise-call-expression": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "6.24.1",
+            "babel-plugin-syntax-async-functions": "6.13.0",
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-define-map": "6.26.0",
+            "babel-helper-function-name": "6.24.1",
+            "babel-helper-optimise-call-expression": "6.24.1",
+            "babel-helper-replace-supers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.26.2",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-strict-mode": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-replace-supers": "6.24.1",
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-call-delegate": "6.24.1",
+            "babel-helper-get-function-arity": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "regexpu-core": "2.0.0"
+          }
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "regenerator-transform": "0.10.1"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-preset-env": {
+          "version": "1.6.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+            "babel-plugin-transform-async-to-generator": "6.24.1",
+            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+            "babel-plugin-transform-es2015-classes": "6.24.1",
+            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+            "babel-plugin-transform-es2015-destructuring": "6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+            "babel-plugin-transform-es2015-for-of": "6.23.0",
+            "babel-plugin-transform-es2015-function-name": "6.24.1",
+            "babel-plugin-transform-es2015-literals": "6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+            "babel-plugin-transform-es2015-object-super": "6.24.1",
+            "babel-plugin-transform-es2015-parameters": "6.24.1",
+            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+            "babel-plugin-transform-es2015-spread": "6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+            "babel-plugin-transform-es2015-template-literals": "6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+            "babel-plugin-transform-exponentiation-operator": "6.24.1",
+            "babel-plugin-transform-regenerator": "6.26.0",
+            "browserslist": "2.11.3",
+            "invariant": "2.2.4",
+            "semver": "5.5.0"
+          }
+        },
+        "babel-register": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "6.26.3",
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.5",
+            "home-or-tmp": "2.0.0",
+            "lodash": "4.17.10",
+            "mkdirp": "0.5.1",
+            "source-map-support": "0.4.18"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "2.5.5",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babelify": {
+          "version": "7.3.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "6.26.3",
+            "object-assign": "4.1.1"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base-x": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "base64-js": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "bignumber.js": {
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+          "bundled": true
+        },
+        "bindings": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "bip39": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "create-hash": "1.2.0",
+            "pbkdf2": "3.0.16",
+            "randombytes": "2.0.6",
+            "safe-buffer": "5.1.2",
+            "unorm": "1.4.1"
+          }
+        },
+        "bip66": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "bl": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.3.6",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "bundled": true
+        },
+        "body-parser": {
+          "version": "1.18.2",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.16"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+              "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+            },
+            "qs": {
+              "version": "6.5.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+            }
+          }
+        },
+        "boom": {
+          "version": "4.3.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "brorand": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "browserify-aes": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "buffer-xor": "1.0.3",
+            "cipher-base": "1.0.4",
+            "create-hash": "1.2.0",
+            "evp_bytestokey": "1.0.3",
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "browserify-cipher": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browserify-aes": "1.2.0",
+            "browserify-des": "1.0.1",
+            "evp_bytestokey": "1.0.3"
+          }
+        },
+        "browserify-des": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "1.0.4",
+            "des.js": "1.0.0",
+            "inherits": "2.0.3"
+          }
+        },
+        "browserify-rsa": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "randombytes": "2.0.6"
+          }
+        },
+        "browserify-sha3": {
+          "version": "0.0.1",
+          "bundled": true,
+          "requires": {
+            "js-sha3": "0.3.1"
+          }
+        },
+        "browserify-sign": {
+          "version": "4.0.4",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "browserify-rsa": "4.0.1",
+            "create-hash": "1.2.0",
+            "create-hmac": "1.1.7",
+            "elliptic": "6.4.0",
+            "inherits": "2.0.3",
+            "parse-asn1": "5.1.1"
+          }
+        },
+        "browserslist": {
+          "version": "2.11.3",
+          "bundled": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000833",
+            "electron-to-chromium": "1.3.45"
+          }
+        },
+        "bs58": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "base-x": "1.1.0"
+          }
+        },
+        "bs58check": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "bs58": "3.1.0",
+            "create-hash": "1.2.0"
+          }
+        },
+        "buffer": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "base64-js": "1.3.0",
+            "ieee754": "1.1.11"
+          }
+        },
+        "buffer-alloc": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "buffer-alloc-unsafe": "0.1.1",
+            "buffer-fill": "0.1.1"
+          }
+        },
+        "buffer-alloc-unsafe": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "buffer-crc32": {
+          "version": "0.2.13",
+          "bundled": true
+        },
+        "buffer-fill": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "buffer-to-arraybuffer": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "buffer-xor": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000833",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "checkpoint-store": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "functional-red-black-tree": "1.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "cipher-base": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "clone": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "coinstring": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "bs58": "2.0.1",
+            "create-hash": "1.2.0"
+          },
+          "dependencies": {
+            "bs58": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
+              "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40="
+            }
+          }
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.8.1",
+          "bundled": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "2.5.5",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cors": {
+          "version": "2.8.4",
+          "bundled": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "vary": "1.1.2"
+          }
+        },
+        "create-ecdh": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "elliptic": "6.4.0"
+          }
+        },
+        "create-hash": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "1.0.4",
+            "inherits": "2.0.3",
+            "md5.js": "1.3.4",
+            "ripemd160": "2.0.2",
+            "sha.js": "2.4.11"
+          }
+        },
+        "create-hmac": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "1.0.4",
+            "create-hash": "1.2.0",
+            "inherits": "2.0.3",
+            "ripemd160": "2.0.2",
+            "safe-buffer": "5.1.2",
+            "sha.js": "2.4.11"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "4.1.2",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "requires": {
+                "hoek": "4.2.1"
+              }
+            }
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "browserify-cipher": "1.0.1",
+            "browserify-sign": "4.0.4",
+            "create-ecdh": "4.0.1",
+            "create-hash": "1.2.0",
+            "create-hmac": "1.1.7",
+            "diffie-hellman": "5.0.3",
+            "inherits": "2.0.3",
+            "pbkdf2": "3.0.16",
+            "public-encrypt": "4.0.2",
+            "randombytes": "2.0.6",
+            "randomfill": "1.0.4"
+          }
+        },
+        "crypto-js": {
+          "version": "3.1.8",
+          "bundled": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "decompress": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "decompress-tar": "4.1.1",
+            "decompress-tarbz2": "4.1.1",
+            "decompress-targz": "4.1.1",
+            "decompress-unzip": "4.0.1",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.2.0",
+            "pify": "2.3.0",
+            "strip-dirs": "2.1.0"
+          }
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "mimic-response": "1.0.0"
+          }
+        },
+        "decompress-tar": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "file-type": "5.2.0",
+            "is-stream": "1.1.0",
+            "tar-stream": "1.6.0"
+          }
+        },
+        "decompress-tarbz2": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "decompress-tar": "4.1.1",
+            "file-type": "6.2.0",
+            "is-stream": "1.1.0",
+            "seek-bzip": "1.0.5",
+            "unbzip2-stream": "1.2.5"
+          },
+          "dependencies": {
+            "file-type": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+              "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+            }
+          }
+        },
+        "decompress-targz": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "decompress-tar": "4.1.1",
+            "file-type": "5.2.0",
+            "is-stream": "1.1.0"
+          }
+        },
+        "decompress-unzip": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "file-type": "3.9.0",
+            "get-stream": "2.3.1",
+            "pify": "2.3.0",
+            "yauzl": "2.9.1"
+          },
+          "dependencies": {
+            "file-type": {
+              "version": "3.9.0",
+              "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+              "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+            },
+            "get-stream": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+              "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+              "requires": {
+                "object-assign": "4.1.1",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "deferred-leveldown": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "abstract-leveldown": "2.6.3"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "foreach": "2.0.5",
+            "object-keys": "1.0.11"
+          }
+        },
+        "defined": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "depd": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "des.js": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.1"
+          }
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "diffie-hellman": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "miller-rabin": "4.0.1",
+            "randombytes": "2.0.6"
+          }
+        },
+        "dom-walk": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "dotenv": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "drbg.js": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browserify-aes": "1.2.0",
+            "create-hash": "1.2.0",
+            "create-hmac": "1.1.7"
+          }
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.45",
+          "bundled": true
+        },
+        "elliptic": {
+          "version": "6.4.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "brorand": "1.1.0",
+            "hash.js": "1.1.3",
+            "hmac-drbg": "1.0.1",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.1",
+            "minimalistic-crypto-utils": "1.0.1"
+          }
+        },
+        "encodeurl": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.21"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "prr": "1.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.11.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "1.1.1",
+            "function-bind": "1.1.1",
+            "has": "1.0.1",
+            "is-callable": "1.1.3",
+            "is-regex": "1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "is-callable": "1.1.3",
+            "is-date-object": "1.0.1",
+            "is-symbol": "1.0.1"
+          }
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "etag": {
+          "version": "1.8.1",
+          "bundled": true
+        },
+        "eth-block-tracker": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+            "eth-query": "2.1.2",
+            "ethereumjs-tx": "1.3.4",
+            "ethereumjs-util": "5.2.0",
+            "ethjs-util": "0.1.4",
+            "json-rpc-engine": "3.6.1",
+            "pify": "2.3.0",
+            "tape": "4.9.0"
+          }
+        },
+        "eth-lib": {
+          "version": "0.1.27",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "elliptic": "6.4.0",
+            "keccakjs": "0.2.1",
+            "nano-json-stream-parser": "0.1.2",
+            "servify": "0.1.12",
+            "ws": "3.3.3",
+            "xhr-request-promise": "0.1.2"
+          }
+        },
+        "eth-query": {
+          "version": "2.1.2",
+          "bundled": true,
+          "requires": {
+            "json-rpc-random-id": "1.0.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "eth-sig-util": {
+          "version": "1.4.2",
+          "bundled": true,
+          "requires": {
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+            "ethereumjs-util": "5.2.0"
+          }
+        },
+        "ethereum-common": {
+          "version": "0.0.18",
+          "bundled": true
+        },
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "ethereumjs-util": "5.2.0"
+          }
+        },
+        "ethereumjs-account": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "ethereumjs-util": "4.5.0",
+            "rlp": "2.0.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+              "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+              "requires": {
+                "bn.js": "4.11.8",
+                "create-hash": "1.2.0",
+                "keccakjs": "0.2.1",
+                "rlp": "2.0.0",
+                "secp256k1": "3.5.0"
+              }
+            }
+          }
+        },
+        "ethereumjs-block": {
+          "version": "1.7.1",
+          "bundled": true,
+          "requires": {
+            "async": "2.6.0",
+            "ethereum-common": "0.2.0",
+            "ethereumjs-tx": "1.3.4",
+            "ethereumjs-util": "5.2.0",
+            "merkle-patricia-tree": "2.3.1"
+          },
+          "dependencies": {
+            "ethereum-common": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+              "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+            }
+          }
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "ethereum-common": "0.0.18",
+            "ethereumjs-util": "5.2.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.2.0",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "secp256k1": "3.5.0"
+          }
+        },
+        "ethereumjs-vm": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "async": "2.6.0",
+            "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+            "ethereum-common": "0.2.0",
+            "ethereumjs-account": "2.0.4",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-util": "5.2.0",
+            "fake-merkle-patricia-tree": "1.0.1",
+            "functional-red-black-tree": "1.0.1",
+            "merkle-patricia-tree": "2.3.1",
+            "rustbn.js": "0.1.2",
+            "safe-buffer": "5.1.2"
+          },
+          "dependencies": {
+            "ethereum-common": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+              "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+            }
+          }
+        },
+        "ethereumjs-wallet": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "aes-js": "0.2.4",
+            "bs58check": "1.3.4",
+            "ethereumjs-util": "4.5.0",
+            "hdkey": "0.7.1",
+            "scrypt.js": "0.2.0",
+            "utf8": "2.1.2",
+            "uuid": "2.0.3"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+              "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+              "requires": {
+                "bn.js": "4.11.8",
+                "create-hash": "1.2.0",
+                "keccakjs": "0.2.1",
+                "rlp": "2.0.0",
+                "secp256k1": "3.5.0"
+              }
+            },
+            "uuid": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+              "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+            }
+          }
+        },
+        "ethjs-unit": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "number-to-bn": "1.7.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            }
+          }
+        },
+        "ethjs-util": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "is-hex-prefixed": "1.0.0",
+            "strip-hex-prefix": "1.0.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "events": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "evp_bytestokey": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "md5.js": "1.3.4",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "expand-template": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "express": {
+          "version": "4.16.3",
+          "bundled": true,
+          "requires": {
+            "accepts": "1.3.5",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.2",
+            "content-disposition": "0.5.2",
+            "content-type": "1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "finalhandler": "1.1.1",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "1.1.2",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "2.0.3",
+            "qs": "6.5.1",
+            "range-parser": "1.2.0",
+            "safe-buffer": "5.1.1",
+            "send": "0.16.2",
+            "serve-static": "1.13.2",
+            "setprototypeof": "1.1.0",
+            "statuses": "1.4.0",
+            "type-is": "1.6.16",
+            "utils-merge": "1.0.1",
+            "vary": "1.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "qs": {
+              "version": "6.5.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fake-merkle-patricia-tree": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "checkpoint-store": "1.1.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-safe-stringify": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "fd-slicer": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "pend": "1.2.0"
+          }
+        },
+        "fetch-ponyfill": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "1.7.3"
+          }
+        },
+        "file-type": {
+          "version": "5.2.0",
+          "bundled": true
+        },
+        "finalhandler": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.4.0",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+            }
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "for-each": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "is-function": "1.0.1"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "fs-constants": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fs-extra": {
+          "version": "0.30.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "fs-promise": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "fs-extra": "2.1.2",
+            "mz": "2.7.0",
+            "thenify-all": "1.6.0"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+              "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "jsonfile": "2.4.0"
+              }
+            }
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "github-from-package": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "global": {
+          "version": "4.3.2",
+          "bundled": true,
+          "requires": {
+            "min-document": "2.19.0",
+            "process": "0.5.2"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true
+        },
+        "got": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-plain-obj": "1.1.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.1",
+            "p-cancelable": "0.3.0",
+            "p-timeout": "1.2.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "1.0.0",
+            "url-to-options": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "function-bind": "1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbol-support-x": {
+          "version": "1.4.2",
+          "bundled": true
+        },
+        "has-to-string-tag-x": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "has-symbol-support-x": "1.4.2"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "hash-base": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.1"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "bundled": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
+          }
+        },
+        "hdkey": {
+          "version": "0.7.1",
+          "bundled": true,
+          "requires": {
+            "coinstring": "2.3.0",
+            "secp256k1": "3.5.0"
+          }
+        },
+        "hmac-drbg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "hash.js": "1.1.3",
+            "minimalistic-assert": "1.0.1",
+            "minimalistic-crypto-utils": "1.0.1"
+          }
+        },
+        "hoek": {
+          "version": "4.2.1",
+          "bundled": true
+        },
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "bundled": true
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "bundled": true,
+          "requires": {
+            "depd": "1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": "1.5.0"
+          }
+        },
+        "http-https": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.11",
+          "bundled": true
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ipaddr.js": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fn": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-function": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-hex-prefixed": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-natural-number": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "is-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "1.0.1"
+          }
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "1.7.3",
+            "whatwg-fetch": "2.0.4"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "isurl": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-to-string-tag-x": "1.4.1",
+            "is-object": "1.0.1"
+          }
+        },
+        "js-sha3": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsesc": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "json-rpc-engine": {
+          "version": "3.6.1",
+          "bundled": true,
+          "requires": {
+            "async": "2.6.0",
+            "babel-preset-env": "1.6.1",
+            "babelify": "7.3.0",
+            "json-rpc-error": "2.0.0",
+            "promise-to-callback": "1.0.0"
+          }
+        },
+        "json-rpc-error": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "json-rpc-random-id": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "bindings": "1.3.0",
+            "inherits": "2.0.3",
+            "nan": "2.10.0",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "keccakjs": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "browserify-sha3": "0.0.1",
+            "sha3": "1.2.2"
+          }
+        },
+        "klaw": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "ledger-wallet-provider": {
+          "version": "2.0.1-beta.2",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "ethereumjs-tx": "1.3.4",
+            "ledgerco": "1.2.1",
+            "promise-timeout": "1.3.0",
+            "strip-hex-prefix": "1.0.0",
+            "web3-provider-engine": "13.8.0"
+          }
+        },
+        "ledgerco": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "node-hid": "0.6.0",
+            "u2f-api": "0.2.7"
+          },
+          "dependencies": {
+            "node-hid": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-0.6.0.tgz",
+              "integrity": "sha512-3fOES92dR7vD5Fb6p28+/hRNmBFYicv/FDMj/d/U2O1Nb4GMpzSf9/HUvewRVVS0JQb6aoLMsxVpAFdIt4U/eA==",
+              "requires": {
+                "bindings": "1.3.0",
+                "nan": "2.10.0",
+                "prebuild-install": "2.5.3"
+              }
+            }
+          }
+        },
+        "level-codec": {
+          "version": "7.0.1",
+          "bundled": true
+        },
+        "level-errors": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "errno": "0.1.7"
+          }
+        },
+        "level-iterator-stream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "level-errors": "1.0.5",
+            "readable-stream": "1.1.14",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            }
+          }
+        },
+        "level-ws": {
+          "version": "0.0.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "2.1.2"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "object-keys": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+              "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+              "requires": {
+                "object-keys": "0.4.0"
+              }
+            }
+          }
+        },
+        "levelup": {
+          "version": "1.3.9",
+          "bundled": true,
+          "requires": {
+            "deferred-leveldown": "1.2.2",
+            "level-codec": "7.0.1",
+            "level-errors": "1.0.5",
+            "level-iterator-stream": "1.3.1",
+            "prr": "1.0.1",
+            "semver": "5.4.1",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.4.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+            }
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "bundled": true
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "ltgt": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "make-dir": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "pify": "3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
+          }
+        },
+        "md5.js": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "hash-base": "3.0.4",
+            "inherits": "2.0.3"
+          }
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "memdown": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "abstract-leveldown": "2.7.2",
+            "functional-red-black-tree": "1.0.1",
+            "immediate": "3.2.3",
+            "inherits": "2.0.3",
+            "ltgt": "2.2.1",
+            "safe-buffer": "5.1.2"
+          },
+          "dependencies": {
+            "abstract-leveldown": {
+              "version": "2.7.2",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+              "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+              "requires": {
+                "xtend": "4.0.1"
+              }
+            }
+          }
+        },
+        "memorystream": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "merkle-patricia-tree": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "async": "1.5.2",
+            "ethereumjs-util": "5.2.0",
+            "level-ws": "0.0.0",
+            "levelup": "1.3.9",
+            "memdown": "1.4.1",
+            "readable-stream": "2.3.6",
+            "rlp": "2.0.0",
+            "semaphore": "1.1.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+            }
+          }
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "miller-rabin": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "brorand": "1.1.0"
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mimic-response": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "min-document": {
+          "version": "2.19.0",
+          "bundled": true,
+          "requires": {
+            "dom-walk": "0.1.1"
+          }
+        },
+        "minimalistic-assert": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimalistic-crypto-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            }
+          }
+        },
+        "mkdirp-promise": {
+          "version": "5.0.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "0.5.1"
+          }
+        },
+        "mock-fs": {
+          "version": "4.4.2",
+          "bundled": true
+        },
+        "mout": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "mz": {
+          "version": "2.7.0",
+          "bundled": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "object-assign": "4.1.1",
+            "thenify-all": "1.6.0"
+          }
+        },
+        "nan": {
+          "version": "2.10.0",
+          "bundled": true
+        },
+        "nano-json-stream-parser": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "node-abi": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "semver": "5.5.0"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "node-hid": {
+          "version": "0.7.2",
+          "bundled": true,
+          "requires": {
+            "bindings": "1.3.0",
+            "nan": "2.10.0",
+            "prebuild-install": "2.5.3"
+          }
+        },
+        "noop-logger": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "number-to-bn": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "strip-hex-prefix": "1.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-inspect": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "bundled": true
+        },
+        "oboe": {
+          "version": "2.1.3",
+          "bundled": true,
+          "requires": {
+            "http-https": "1.0.0"
+          }
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "1.2.0"
+          }
+        },
+        "p-timeout": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "p-finally": "1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parse-asn1": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "4.10.1",
+            "browserify-aes": "1.2.0",
+            "create-hash": "1.2.0",
+            "evp_bytestokey": "1.0.3",
+            "pbkdf2": "3.0.16"
+          }
+        },
+        "parse-headers": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "for-each": "0.3.2",
+            "trim": "0.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pbkdf2": {
+          "version": "3.0.16",
+          "bundled": true,
+          "requires": {
+            "create-hash": "1.2.0",
+            "create-hmac": "1.1.7",
+            "ripemd160": "2.0.2",
+            "safe-buffer": "5.1.2",
+            "sha.js": "2.4.11"
+          }
+        },
+        "pend": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "prebuild-install": {
+          "version": "2.5.3",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.0",
+            "github-from-package": "0.0.0",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.4.1",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.7",
+            "simple-get": "2.8.1",
+            "tar-fs": "1.16.2",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "private": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "process": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "promise-timeout": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "promise-to-callback": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-fn": "1.0.0",
+            "set-immediate-shim": "1.0.1"
+          }
+        },
+        "proxy-addr": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "forwarded": "0.1.2",
+            "ipaddr.js": "1.6.0"
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "public-encrypt": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "browserify-rsa": "4.0.1",
+            "create-hash": "1.2.0",
+            "parse-asn1": "5.1.1",
+            "randombytes": "2.0.6"
+          }
+        },
+        "pump": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "decode-uri-component": "0.2.0",
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
+        },
+        "randombytes": {
+          "version": "2.0.6",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "randomfill": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "randombytes": "2.0.6",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "randomhex": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.5.0"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+              "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+            }
+          }
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "regenerate": {
+          "version": "1.3.3",
+          "bundled": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "regenerator-transform": {
+          "version": "0.10.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "private": "0.1.8"
+          }
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "jsesc": "0.5.0"
+          }
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.85.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-from-string": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        },
+        "resumer": {
+          "version": "0.0.0",
+          "bundled": true,
+          "requires": {
+            "through": "2.3.8"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "ripemd160": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "hash-base": "3.0.4",
+            "inherits": "2.0.3"
+          }
+        },
+        "rlp": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "rustbn.js": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "scrypt": {
+          "version": "6.0.3",
+          "bundled": true,
+          "requires": {
+            "nan": "2.10.0"
+          }
+        },
+        "scrypt.js": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "scrypt": "6.0.3",
+            "scryptsy": "1.2.1"
+          }
+        },
+        "scryptsy": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "pbkdf2": "3.0.16"
+          }
+        },
+        "secp256k1": {
+          "version": "3.5.0",
+          "bundled": true,
+          "requires": {
+            "bindings": "1.3.0",
+            "bip66": "1.1.5",
+            "bn.js": "4.11.8",
+            "create-hash": "1.2.0",
+            "drbg.js": "1.0.1",
+            "elliptic": "6.4.0",
+            "nan": "2.10.0",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "seek-bzip": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "commander": "2.8.1"
+          }
+        },
+        "semaphore": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "send": {
+          "version": "0.16.2",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.3",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.4.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.13.2",
+          "bundled": true,
+          "requires": {
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
+            "send": "0.16.2"
+          }
+        },
+        "servify": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "body-parser": "1.18.2",
+            "cors": "2.8.4",
+            "express": "4.16.3",
+            "request": "2.85.0",
+            "xhr": "2.4.1"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "sha.js": {
+          "version": "2.4.11",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "sha3": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "nan": "2.10.0"
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "simple-concat": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "simple-get": {
+          "version": "2.8.1",
+          "bundled": true,
+          "requires": {
+            "decompress-response": "3.3.0",
+            "once": "1.4.0",
+            "simple-concat": "1.0.0"
+          }
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "solc": {
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "fs-extra": "0.30.0",
+            "memorystream": "0.3.1",
+            "require-from-string": "1.2.1",
+            "semver": "5.5.0",
+            "yargs": "4.8.1"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "4.8.1",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+              "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+              "requires": {
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "lodash.assign": "4.2.0",
+                "os-locale": "1.4.0",
+                "read-pkg-up": "1.0.1",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "1.0.2",
+                "which-module": "1.0.0",
+                "window-size": "0.2.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "2.4.1"
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "bundled": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string.prototype.trim": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "define-properties": "1.1.2",
+            "es-abstract": "1.11.0",
+            "function-bind": "1.1.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-dirs": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "is-natural-number": "4.0.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-hex-prefix": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-hex-prefixed": "1.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "swarm-js": {
+          "version": "0.1.37",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "buffer": "5.1.0",
+            "decompress": "4.2.0",
+            "eth-lib": "0.1.27",
+            "fs-extra": "2.1.2",
+            "fs-promise": "2.0.3",
+            "got": "7.1.0",
+            "mime-types": "2.1.18",
+            "mkdirp-promise": "5.0.1",
+            "mock-fs": "4.4.2",
+            "setimmediate": "1.0.5",
+            "tar.gz": "1.0.7",
+            "xhr-request-promise": "0.1.2"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+              "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "jsonfile": "2.4.0"
+              }
+            }
+          }
+        },
+        "tape": {
+          "version": "4.9.0",
+          "bundled": true,
+          "requires": {
+            "deep-equal": "1.0.1",
+            "defined": "1.0.0",
+            "for-each": "0.3.2",
+            "function-bind": "1.1.1",
+            "glob": "7.1.2",
+            "has": "1.0.1",
+            "inherits": "2.0.3",
+            "minimist": "1.2.0",
+            "object-inspect": "1.5.0",
+            "resolve": "1.5.0",
+            "resumer": "0.0.0",
+            "string.prototype.trim": "1.1.2",
+            "through": "2.3.8"
+          }
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-fs": {
+          "version": "1.16.2",
+          "bundled": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pump": "1.0.3",
+            "tar-stream": "1.6.0"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+              "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            }
+          }
+        },
+        "tar-stream": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "bl": "1.2.2",
+            "buffer-alloc": "1.1.0",
+            "end-of-stream": "1.4.1",
+            "fs-constants": "1.0.0",
+            "readable-stream": "2.3.6",
+            "to-buffer": "1.1.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "tar.gz": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "bluebird": "2.11.0",
+            "commander": "2.8.1",
+            "fstream": "1.0.11",
+            "mout": "0.11.1",
+            "tar": "2.2.1"
+          },
+          "dependencies": {
+            "bluebird": {
+              "version": "2.11.0",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+              "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+            }
+          }
+        },
+        "thenify": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "any-promise": "1.3.0"
+          }
+        },
+        "thenify-all": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "thenify": "3.3.0"
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "to-buffer": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "trim": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "truffle-hdwallet-provider": {
+          "version": "0.0.3",
+          "bundled": true,
+          "requires": {
+            "bip39": "2.5.0",
+            "ethereumjs-wallet": "0.6.0",
+            "web3": "0.18.4",
+            "web3-provider-engine": "8.6.1"
+          },
+          "dependencies": {
+            "web3": {
+              "version": "0.18.4",
+              "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+              "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+              "requires": {
+                "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+                "crypto-js": "3.1.8",
+                "utf8": "2.1.2",
+                "xhr2": "0.1.4",
+                "xmlhttprequest": "1.8.0"
+              }
+            },
+            "web3-provider-engine": {
+              "version": "8.6.1",
+              "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
+              "integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
+              "requires": {
+                "async": "2.6.0",
+                "clone": "2.1.1",
+                "ethereumjs-block": "1.7.1",
+                "ethereumjs-tx": "1.3.4",
+                "ethereumjs-util": "5.2.0",
+                "ethereumjs-vm": "2.3.5",
+                "isomorphic-fetch": "2.2.1",
+                "request": "2.85.0",
+                "semaphore": "1.1.0",
+                "solc": "0.4.23",
+                "tape": "4.9.0",
+                "web3": "0.16.0",
+                "xhr": "2.4.1",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "bignumber.js": {
+                  "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+                },
+                "web3": {
+                  "version": "0.16.0",
+                  "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+                  "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+                  "requires": {
+                    "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+                    "crypto-js": "3.1.8",
+                    "utf8": "2.1.2",
+                    "xmlhttprequest": "1.8.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-is": {
+          "version": "1.6.16",
+          "bundled": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "2.1.18"
+          }
+        },
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "bundled": true,
+          "requires": {
+            "is-typedarray": "1.0.0"
+          }
+        },
+        "u2f-api": {
+          "version": "0.2.7",
+          "bundled": true
+        },
+        "ultron": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "unbzip2-stream": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "buffer": "3.6.0",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "base64-js": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+              "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+            },
+            "buffer": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+              "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+              "requires": {
+                "base64-js": "0.0.8",
+                "ieee754": "1.1.11",
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "bundled": true
+        },
+        "unorm": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "1.0.4"
+          }
+        },
+        "url-set-query": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "url-to-options": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "utf8": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
+          }
+        },
+        "vary": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          }
+        },
+        "web3": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "web3-bzz": "1.0.0-beta.30",
+            "web3-core": "1.0.0-beta.30",
+            "web3-eth": "1.0.0-beta.30",
+            "web3-eth-personal": "1.0.0-beta.30",
+            "web3-net": "1.0.0-beta.30",
+            "web3-shh": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "got": "7.1.0",
+            "swarm-js": "0.1.37",
+            "underscore": "1.8.3"
+          }
+        },
+        "web3-core": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-core-requestmanager": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-eth-iban": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-promievent": "1.0.0-beta.30",
+            "web3-core-subscriptions": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.3.1",
+            "eventemitter3": "1.1.1"
+          },
+          "dependencies": {
+            "bluebird": {
+              "version": "3.3.1",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
+              "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
+            }
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-providers-http": "1.0.0-beta.30",
+            "web3-providers-ipc": "1.0.0-beta.30",
+            "web3-providers-ws": "1.0.0-beta.30"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "eventemitter3": "1.1.1",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30"
+          }
+        },
+        "web3-eth": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-core-subscriptions": "1.0.0-beta.30",
+            "web3-eth-abi": "1.0.0-beta.30",
+            "web3-eth-accounts": "1.0.0-beta.30",
+            "web3-eth-contract": "1.0.0-beta.30",
+            "web3-eth-iban": "1.0.0-beta.30",
+            "web3-eth-personal": "1.0.0-beta.30",
+            "web3-net": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.3.1",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scrypt.js": "0.2.0",
+            "underscore": "1.8.3",
+            "uuid": "2.0.1",
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          },
+          "dependencies": {
+            "bluebird": {
+              "version": "3.3.1",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
+              "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0",
+                "xhr-request-promise": "0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+              "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-core-promievent": "1.0.0-beta.30",
+            "web3-core-subscriptions": "1.0.0-beta.30",
+            "web3-eth-abi": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-net": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-net": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-utils": "1.0.0-beta.30"
+          }
+        },
+        "web3-provider-engine": {
+          "version": "13.8.0",
+          "bundled": true,
+          "requires": {
+            "async": "2.6.0",
+            "clone": "2.1.1",
+            "eth-block-tracker": "2.3.1",
+            "eth-sig-util": "1.4.2",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-tx": "1.3.4",
+            "ethereumjs-util": "5.2.0",
+            "ethereumjs-vm": "2.3.5",
+            "fetch-ponyfill": "4.1.0",
+            "json-rpc-error": "2.0.0",
+            "json-stable-stringify": "1.0.1",
+            "promise-to-callback": "1.0.0",
+            "readable-stream": "2.3.6",
+            "request": "2.85.0",
+            "semaphore": "1.1.0",
+            "solc": "0.4.23",
+            "tape": "4.9.0",
+            "xhr": "2.4.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.30",
+            "xhr2": "0.1.4"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "oboe": "2.1.3",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.30",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+          }
+        },
+        "web3-shh": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "web3-core": "1.0.0-beta.30",
+            "web3-core-method": "1.0.0-beta.30",
+            "web3-core-subscriptions": "1.0.0-beta.30",
+            "web3-net": "1.0.0-beta.30"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.30",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            },
+            "utf8": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+              "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
+            }
+          }
+        },
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "nan": "2.10.0",
+            "typedarray-to-buffer": "3.1.5",
+            "yaeti": "0.0.6"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "which-pm-runs": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "ws": {
+          "version": "3.3.3",
+          "bundled": true,
+          "requires": {
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.2",
+            "ultron": "1.1.1"
+          }
+        },
+        "xhr": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "global": "4.3.2",
+            "is-function": "1.0.1",
+            "parse-headers": "2.0.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "xhr-request": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "buffer-to-arraybuffer": "0.0.5",
+            "object-assign": "4.1.1",
+            "query-string": "5.1.1",
+            "simple-get": "2.8.1",
+            "timed-out": "4.0.1",
+            "url-set-query": "1.0.0",
+            "xhr": "2.4.1"
+          }
+        },
+        "xhr-request-promise": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "xhr-request": "1.1.0"
+          }
+        },
+        "xhr2": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "xmlhttprequest": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "yaeti": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "11.0.0",
+          "bundled": true,
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            },
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+            },
+            "cliui": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+              "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+              "requires": {
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "requires": {
+                "locate-path": "2.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+              "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+              "requires": {
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+            },
+            "yargs-parser": {
+              "version": "9.0.2",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+              "requires": {
+                "camelcase": "4.1.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
+          }
+        },
+        "yauzl": {
+          "version": "2.9.1",
+          "bundled": true,
+          "requires": {
+            "buffer-crc32": "0.2.13",
+            "fd-slicer": "1.0.1"
+          }
+        }
+      }
+    },
     "dotenv": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
@@ -2017,24 +6509,6 @@
         "strip-eof": "1.0.0"
       }
     },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "optional": true,
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "optional": true,
-      "requires": {
-        "fill-range": "2.2.3"
-      }
-    },
     "expand-template": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
@@ -2107,15 +6581,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "optional": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -2159,25 +6624,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "optional": true
-    },
-    "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "optional": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
     },
     "finalhandler": {
       "version": "1.1.1",
@@ -2223,21 +6669,6 @@
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "requires": {
         "is-function": "1.0.1"
-      }
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "optional": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "optional": true,
-      "requires": {
-        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -2309,477 +6740,10 @@
         }
       }
     },
-    "fs-readdir-recursive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
-      "optional": true,
-      "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "2.2.4"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "2.1.2"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.11"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "2.2.4"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.9.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.6",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true
-        }
-      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -2851,24 +6815,6 @@
         "minimatch": "3.0.4",
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "optional": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "requires": {
-        "is-glob": "2.0.1"
       }
     },
     "global": {
@@ -3122,20 +7068,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
-    "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "optional": true,
-      "requires": {
-        "binary-extensions": "1.11.0"
-      }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
@@ -3153,32 +7085,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "optional": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "optional": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "optional": true
-    },
-    "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -3206,14 +7112,6 @@
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
       "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
-    "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
     "is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
@@ -3224,15 +7122,6 @@
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
     },
-    "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "optional": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
@@ -3242,18 +7131,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "optional": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "optional": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -3297,15 +7174,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "optional": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -3446,14 +7314,6 @@
       "requires": {
         "browserify-sha3": "0.0.1",
         "sha3": "1.2.2"
-      }
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -3769,27 +7629,6 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
-    "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "optional": true,
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
-      }
-    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -3964,14 +7803,6 @@
         "validate-npm-package-license": "3.0.3"
       }
     },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "requires": {
-        "remove-trailing-separator": "1.1.0"
-      }
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -4032,16 +7863,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "optional": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
-    },
     "oboe": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
@@ -4083,16 +7904,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "output-file-sync": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
     },
     "p-cancelable": {
       "version": "0.3.0",
@@ -4143,18 +7954,6 @@
         "create-hash": "1.2.0",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.16"
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "optional": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
       }
     },
     "parse-headers": {
@@ -4284,12 +8083,6 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "optional": true
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -4377,47 +8170,6 @@
         "decode-uri-component": "0.2.0",
         "object-assign": "4.1.1",
         "strict-uri-encode": "1.1.0"
-      }
-    },
-    "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "optional": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "optional": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "optional": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
       }
     },
     "randombytes": {
@@ -4530,18 +8282,6 @@
         "util-deprecate": "1.0.2"
       }
     },
-    "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.6",
-        "set-immediate-shim": "1.0.1"
-      }
-    },
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
@@ -4560,15 +8300,6 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "private": "0.1.8"
-      }
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "optional": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3"
       }
     },
     "regexpu-core": {
@@ -4593,22 +8324,6 @@
       "requires": {
         "jsesc": "0.5.0"
       }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-    },
-    "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "optional": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -5015,14 +8730,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5041,6 +8748,14 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.11.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
       }
     },
     "stringstream": {
@@ -5430,11 +9145,6 @@
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
-    "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
-    },
     "utf8": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
@@ -5454,14 +9164,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-    },
-    "v8flags": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "requires": {
-        "user-home": "1.1.1"
-      }
     },
     "validate-npm-package-license": {
       "version": "3.0.3",

--- a/dot-abi-cli/examples/cryptokitties-cli/package.json
+++ b/dot-abi-cli/examples/cryptokitties-cli/package.json
@@ -2,18 +2,21 @@
   "name": "cryptokitties-cli",
   "version": "0.0.1",
   "description": "CLI tools for interacting with cryptokitties",
-  "main": "index.js",
+  "main": "cryptokitties.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "engines": {
+    "node": ">=8"
   },
   "author": "Dotta <cryppadotta@protonmail.com>",
   "license": "MIT",
   "dependencies": {
     "@ledgerhq/hw-app-eth": "^4.2.0",
-    "babel-cli": "^6.26.0",
     "bluebird": "^3.5.1",
     "chalk": "^2.3.1",
     "debug": "^3.1.0",
+    "dot-abi-cli": "../..",
     "dotenv": "^5.0.0",
     "ledger-wallet-provider": "^2.0.1-beta.2",
     "lodash": "^4.17.5",


### PR DESCRIPTION
Greetings. Lurking to watch your recurring payments chatter and saw this abi cli builder and found it interesting. Tried running the example and I get:
```
Error: Cannot find module 'debug'
```
basically you're missing the dependencies from dot-abi-cli's package.json Easily fixed in package.json with
```
    "dot-abi-cli": "../..",
```
and in cryptokitties-cli.js
```
const dotAbiCli = require('dot-abi-cli');
```

that aside, I don't think babel is actually buying you anything currently as it doesnt run in 6.x because it cant find es2017 presets. But if I add it to the example I still get:

```
jacobs-air:cryptokitties-cli jacobrosenthal$ ./node_modules/.bin/babel-node --presets es2017 cryptokitties-cli.js --help
/Users/jacobrosenthal/Downloads/dotta-license/dot-abi-cli/examples/cryptokitties-cli/node_modules/babel-core/lib/transformation/file/options/option-manager.js:328
        throw e;
        ^

Error: Couldn't find preset "es2017" relative to directory "/Users/jacobrosenthal/Downloads/dotta-license/dot-abi-cli"
```
I could be wrong, but Im not sure how to fix that other than adding the preset dep to the dot-abi-cli package.json which nobody wants..


How about instead, Im sure you know, node 6.x LTS is now EOL, and node 8.x is Active LTS which has access to async/await, so perhaps locking to
```
  "engines": {
    "node": ">=8"
  },
```
and updating the readme to the simpler
```
node cryptokitties-cli.js --help
```